### PR TITLE
Chore: setup aliases

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,7 +32,7 @@ export default tseslint.config(
             // Packages. `react` related packages come first.
             ["^react", "^@?\\w"],
             // Internal packages.
-            ["^(components|utils|hooks|config|vendored-lib)(/.*|$)"],
+            ["^(components|pages|utils|hooks|config|vendored-lib)(/.*|$)"],
             // Side effect imports.
             ["^\\u0000"],
             // Parent imports. Put `..` last.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,7 +32,9 @@ export default tseslint.config(
             // Packages. `react` related packages come first.
             ["^react", "^@?\\w"],
             // Internal packages.
-            ["^(components|pages|utils|hooks|config|vendored-lib)(/.*|$)"],
+            [
+              "^(components|pages|utils|hooks|config|vendored-lib|icons|settings|types)(/.*|$)",
+            ],
             // Side effect imports.
             ["^\\u0000"],
             // Parent imports. Put `..` last.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-router": "^7.6.0",
         "react-router-dom": "^7.6.2",
         "sass": "^1.89.1",
+        "vite-tsconfig-paths": "^5.1.4",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -2676,7 +2677,7 @@
       "version": "0.25.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
       "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -3171,6 +3172,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -3638,7 +3644,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -3806,7 +3812,7 @@
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
       "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4342,7 +4348,7 @@
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
       "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "fdir": "^6.4.4",
         "picomatch": "^4.0.2"
@@ -4358,7 +4364,7 @@
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
       "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -4372,7 +4378,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=12"
       },
@@ -4784,7 +4790,7 @@
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4876,11 +4882,62 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
+      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-tsconfig-paths/node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
       "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -4894,7 +4951,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=12"
       },
@@ -4906,7 +4963,7 @@
       "version": "4.44.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.0.tgz",
       "integrity": "sha512-qHcdEzLCiktQIfwBq420pn2dP+30uzqYxv9ETm91wdt2R9AFcWfjNAmje4NWlnCIQ5RMTzVf0ZyisOKqHR6RwA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-router": "^7.6.0",
     "react-router-dom": "^7.6.2",
     "sass": "^1.89.1",
+    "vite-tsconfig-paths": "^5.1.4",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -2,6 +2,7 @@ import React, { Suspense } from "react";
 import { Route, Routes } from "react-router-dom";
 import Layout from "@components/layout";
 import Loader from "@components/loader";
+
 import { AppRoute } from "settings";
 
 const NotFoundPage = React.lazy(() => import("@pages/not-found"));

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -1,19 +1,14 @@
 import React, { Suspense } from "react";
 import { Route, Routes } from "react-router-dom";
+import Layout from "@components/layout";
+import Loader from "@components/loader";
+import { AppRoute } from "settings";
 
-import { AppRoute } from "../../settings";
-import Layout from "../layout";
-import Loader from "../loader";
-
-const NotFoundPage = React.lazy(() => import("../../pages/not-found"));
-const HomePage = React.lazy(() => import("../../pages/home"));
-const CharactersPage = React.lazy(() => import("../../pages/characters/list"));
-const CharacterDetailsPage = React.lazy(
-  () => import("../../pages/characters/item")
-);
-const CharacterFormPage = React.lazy(
-  () => import("../../pages/characters/form")
-);
+const NotFoundPage = React.lazy(() => import("@pages/not-found"));
+const HomePage = React.lazy(() => import("@pages/home"));
+const CharactersPage = React.lazy(() => import("@pages/characters/list"));
+const CharacterDetailsPage = React.lazy(() => import("@pages/characters/item"));
+const CharacterFormPage = React.lazy(() => import("@pages/characters/form"));
 
 const App = () => {
   return (

--- a/src/components/avatar/index.tsx
+++ b/src/components/avatar/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { avatar as avatarIcon } from "@icons";
+import { avatar as avatarIcon } from "icons";
 
 import "./avatar.scss";
 

--- a/src/components/avatar/index.tsx
+++ b/src/components/avatar/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { avatar as avatarIcon } from "icons";
 
 import "./avatar.scss";

--- a/src/components/avatar/index.tsx
+++ b/src/components/avatar/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-
-import { avatar as avatarIcon } from "../../icons";
+import { avatar as avatarIcon } from "@icons";
 
 import "./avatar.scss";
 

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from "react";
 import { Link, NavLink, Outlet, useLocation } from "react-router-dom";
 import Loader from "@components/loader";
+
 import { logo } from "icons";
 import { AppRoute } from "settings";
 

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,9 +1,8 @@
 import React, { Suspense } from "react";
 import { Link, NavLink, Outlet, useLocation } from "react-router-dom";
-
-import { logo } from "../../icons";
-import { AppRoute } from "../../settings";
-import Loader from "../loader";
+import Loader from "@components/loader";
+import { logo } from "icons";
+import { AppRoute } from "settings";
 
 import "./layout.scss";
 

--- a/src/components/list/index.tsx
+++ b/src/components/list/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { useCharacters } from "@context/character";
+
 import { avatar } from "icons";
 import { AppRoute } from "settings";
 

--- a/src/components/list/index.tsx
+++ b/src/components/list/index.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { Link } from "react-router-dom";
-
-import { useCharacters } from "../../context/character";
-import { avatar } from "../../icons";
-import { AppRoute } from "../../settings";
+import { useCharacters } from "@context/character";
+import { avatar } from "icons";
+import { AppRoute } from "settings";
 
 import "./list.scss";
 

--- a/src/components/modal/content.tsx
+++ b/src/components/modal/content.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-
-import Button from "../button";
+import Button from "@components/button";
 
 import "./content.scss";
 

--- a/src/components/toast-notifications/index.tsx
+++ b/src/components/toast-notifications/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-
-import { useNotifications } from "../../context/notifications";
+import { useNotifications } from "@context/notifications";
 
 import ToastNotification from "./toast";
 

--- a/src/components/toast-notifications/toast/index.tsx
+++ b/src/components/toast-notifications/toast/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-
-import { Notification, useNotifications } from "../../../context/notifications";
-import { circleCheck, circlePlus, closingCross } from "../../../icons";
+import { Notification, useNotifications } from "@context/notifications";
+import { circleCheck, circlePlus, closingCross } from "icons";
 
 import "./toast.scss";
 

--- a/src/components/toast-notifications/toast/index.tsx
+++ b/src/components/toast-notifications/toast/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Notification, useNotifications } from "@context/notifications";
+
 import { circleCheck, circlePlus, closingCross } from "icons";
 
 import "./toast.scss";

--- a/src/context/character.tsx
+++ b/src/context/character.tsx
@@ -7,8 +7,8 @@ import {
 } from "react";
 import { useLocalStorage } from "@hooks/use-local-storage";
 import { FormFields } from "@pages/characters/form";
-import { Character } from "types/character";
 
+import { Character } from "types/character";
 import { buildCoreAbilities } from "utils";
 
 type CharacterProps = {

--- a/src/context/character.tsx
+++ b/src/context/character.tsx
@@ -5,11 +5,11 @@ import {
   useEffect,
   useState,
 } from "react";
+import { useLocalStorage } from "@hooks/use-local-storage";
+import { FormFields } from "@pages/characters/form";
+import { Character } from "types/character";
 
-import { useLocalStorage } from "../hooks/use-local-storage";
-import { FormFields } from "../pages/characters/form";
-import { Character } from "../types/character";
-import { buildCoreAbilities } from "../utils";
+import { buildCoreAbilities } from "utils";
 
 type CharacterProps = {
   children: ReactNode;

--- a/src/hooks/use-local-storage.tsx
+++ b/src/hooks/use-local-storage.tsx
@@ -1,4 +1,5 @@
 import { useNotifications } from "@context/notifications";
+
 import { ERROR_NOTIFICATIONS, SUCCESS_NOTIFICATIONS } from "settings";
 
 export const useLocalStorage = (key: string) => {

--- a/src/hooks/use-local-storage.tsx
+++ b/src/hooks/use-local-storage.tsx
@@ -1,5 +1,5 @@
-import { useNotifications } from "../context/notifications";
-import { ERROR_NOTIFICATIONS, SUCCESS_NOTIFICATIONS } from "../settings";
+import { useNotifications } from "@context/notifications";
+import { ERROR_NOTIFICATIONS, SUCCESS_NOTIFICATIONS } from "settings";
 
 export const useLocalStorage = (key: string) => {
   const { addNotification } = useNotifications();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
-
-import App from "./components/app/App";
-import ToastNotifications from "./components/toast-notifications";
-import { CharacterProvider } from "./context/character";
-import { NotificationsProvider } from "./context/notifications";
+import App from "@components/app/App";
+import ToastNotifications from "@components/toast-notifications";
+import { CharacterProvider } from "@context/character";
+import { NotificationsProvider } from "@context/notifications";
 
 import "./index.scss";
 

--- a/src/pages/characters/form/index.tsx
+++ b/src/pages/characters/form/index.tsx
@@ -5,6 +5,7 @@ import AvatarPicker from "@components/avatar/picker";
 import Button from "@components/button";
 import { useCharacters } from "@context/character";
 import NotFoundPage from "@pages/not-found";
+
 import { AppRoute, CORE_ABILITIES } from "settings";
 import { Character } from "types/character";
 

--- a/src/pages/characters/form/index.tsx
+++ b/src/pages/characters/form/index.tsx
@@ -1,16 +1,15 @@
 import React, { useId } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { useNavigate, useParams } from "react-router-dom";
+import AvatarPicker from "@components/avatar/picker";
+import Button from "@components/button";
+import { useCharacters } from "@context/character";
+import NotFoundPage from "@pages/not-found";
+import { AppRoute, CORE_ABILITIES } from "settings";
+import { Character } from "types/character";
 
-import AvatarPicker from "../../../components/avatar/picker";
-import Button from "../../../components/button";
-import { useCharacters } from "../../../context/character";
-import { AppRoute, CORE_ABILITIES } from "../../../settings";
-import { Character } from "../../../types/character";
-import NotFoundPage from "../../not-found";
-
-import "./form.scss";
 import "../../../index.scss";
+import "./form.scss";
 
 const validationErrors = {
   required: "This field is required",

--- a/src/pages/characters/item/index.tsx
+++ b/src/pages/characters/item/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import Avatar from "@components/avatar";
 import { useCharacters } from "@context/character";
+
 import { arrowLeft as arrowLeftIcon, edit as editIcon } from "icons";
 import { AppRoute, CORE_ABILITIES } from "settings";
 

--- a/src/pages/characters/item/index.tsx
+++ b/src/pages/characters/item/index.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useMemo } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-
-import Avatar from "../../../components/avatar";
-import { useCharacters } from "../../../context/character";
-import { arrowLeft as arrowLeftIcon, edit as editIcon } from "../../../icons";
-import { AppRoute, CORE_ABILITIES } from "../../../settings";
+import Avatar from "@components/avatar";
+import { useCharacters } from "@context/character";
+import { arrowLeft as arrowLeftIcon, edit as editIcon } from "icons";
+import { AppRoute, CORE_ABILITIES } from "settings";
 
 import "./item.scss";
 

--- a/src/pages/characters/list/index.tsx
+++ b/src/pages/characters/list/index.tsx
@@ -5,6 +5,7 @@ import Modal from "@components/modal";
 import ConfirmationModalContent from "@components/modal/content";
 import { useCharacters } from "@context/character";
 import { useModal } from "@hooks/use-modal";
+
 import { AppRoute } from "settings";
 
 import "./characters.scss";

--- a/src/pages/characters/list/index.tsx
+++ b/src/pages/characters/list/index.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { Link } from "react-router-dom";
-
-import CharactersList from "../../../components/list";
-import Modal from "../../../components/modal";
-import ConfirmationModalContent from "../../../components/modal/content";
-import { useCharacters } from "../../../context/character";
-import { useModal } from "../../../hooks/use-modal";
-import { AppRoute } from "../../../settings";
+import CharactersList from "@components/list";
+import Modal from "@components/modal";
+import ConfirmationModalContent from "@components/modal/content";
+import { useCharacters } from "@context/character";
+import { useModal } from "@hooks/use-modal";
+import { AppRoute } from "settings";
 
 import "./characters.scss";
 

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-
-import { AppRoute } from "../../settings";
+import { AppRoute } from "settings";
 
 import "../../index.scss";
 import "./home.scss";

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
+
 import { AppRoute } from "settings";
 
 import "../../index.scss";

--- a/src/pages/not-found/index.tsx
+++ b/src/pages/not-found/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-
-import { AppRoute } from "../../settings";
+import { AppRoute } from "settings";
 
 import "./not-found.scss";
 

--- a/src/pages/not-found/index.tsx
+++ b/src/pages/not-found/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
+
 import { AppRoute } from "settings";
 
 import "./not-found.scss";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { FormFields } from "./pages/characters/form";
+import { FormFields } from "@pages/characters/form";
 
 export const buildCoreAbilities = (data: FormFields) => {
   return {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,20 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "es5",
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
+    "baseUrl": "./src",
+    "paths": {
+      "@components/*": ["components/*"],
+      "@context/*": ["context/*"],
+      "@hooks/*": ["hooks/*"],
+      "@pages/*": ["pages/*"],
+      "@settings": ["settings.ts"],
+      "@styles/*": ["index.scss"],
+      "types/*": ["types/*"],
+      "@utils/*": ["utils.ts"]
+      // add more aliases here
+    },
+    "outDir": "./dist"
   },
   "include": ["src", "vite.config.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,10 +23,10 @@
       "@context/*": ["context/*"],
       "@hooks/*": ["hooks/*"],
       "@pages/*": ["pages/*"],
-      "@settings": ["settings.ts"],
+      "icons": ["icons.ts"],
+      "settings": ["settings.ts"],
       "types/*": ["types/*"],
-      "@utils/*": ["utils.ts"],
-      "@icons": ["icons.ts"]
+      "utils/*": ["utils.ts"]
     },
     "outDir": "./dist"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,10 +24,9 @@
       "@hooks/*": ["hooks/*"],
       "@pages/*": ["pages/*"],
       "@settings": ["settings.ts"],
-      "@styles/*": ["index.scss"],
       "types/*": ["types/*"],
-      "@utils/*": ["utils.ts"]
-      // add more aliases here
+      "@utils/*": ["utils.ts"],
+      "@icons": ["icons.ts"]
     },
     "outDir": "./dist"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,10 +23,10 @@
       "@context/*": ["context/*"],
       "@hooks/*": ["hooks/*"],
       "@pages/*": ["pages/*"],
-      "icons": ["icons.ts"],
-      "settings": ["settings.ts"],
-      "types/*": ["types/*"],
-      "utils/*": ["utils.ts"]
+      "@settings": ["settings.ts"],
+      "@utils*": ["utils.ts"],
+      "@icons": ["icons.ts"],
+      "types/*": ["types/*"]
     },
     "outDir": "./dist"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tsconfigPaths()],
   build: {
     outDir: "build",
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+  plugins: [tsconfigPaths(), react()],
   build: {
     outDir: "build",
   },


### PR DESCRIPTION
**Pull Request Overview**

This PR introduces path aliases to simplify and standardize import statements across the project by configuring Vite and updating imports accordingly.

* Added the vite-tsconfig-paths plugin for alias resolution.
* Replaced relative imports in source files with new aliases (e.g., @components, settings, icons).
* Updated ESLint config to recognize new alias groups and added the plugin dependency.